### PR TITLE
Update Orchestra

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
-            testbench: 9.*
+            testbench: 10.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require --dev "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests


### PR DESCRIPTION
Update orchestra/testbench version from 9.* to 10.* for Laravel 12 tests. Testbench 9.* only supports Laravel 11.*, while Laravel 12 requires Testbench 10.*. This was causing dependency resolution failures during workflow runs.